### PR TITLE
Replace archived Watchtower image with maintained fork

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,7 +36,7 @@ services:
     restart: unless-stopped
 
   watchtower:
-    image: containrrr/watchtower:latest
+    image: nickfedor/watchtower:latest
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     # Watchtower checks every 5 minutes (300 seconds) for new images and cleans up the old ones to save disk space


### PR DESCRIPTION
This pull request updates the Docker image used for the `watchtower` service to a maintained fork in the `docker-compose.prod.yml` file.

- Changed the `watchtower` service image from `containrrr/watchtower:latest` to `nickfedor/watchtower:latest` (`docker-compose.prod.yml`)