### PR TITLE
fix(dashboard): keep system cards on one row

### DIFF
--- a/monitoring/dashboard/static/style.css
+++ b/monitoring/dashboard/static/style.css
@@ -186,7 +186,7 @@ h1 {
 }
 
 .telemetry-grid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
 .runtime-grid .metric {


### PR DESCRIPTION
When Temp appears it appears in its own row for telemetry, now appears on 1 row 