### PR TITLE
Fix/too complex error

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -310,6 +310,7 @@ async def on_ready():
 
 
 DEFAULT_DPI = 300
+DISCORD_MODAL_LATEX_INPUT_CHARS = 4000
 
 
 class LatexCodeModal(discord.ui.Modal):
@@ -318,7 +319,9 @@ class LatexCodeModal(discord.ui.Modal):
         style=discord.TextStyle.long,
         placeholder="Enter your LaTeX code here...",
         required=True,
-        max_length=MAX_LATEX_INPUT_CHARS,
+        # Keep the renderer limit at 3000, but allow the modal to submit
+        # slightly more so the backend can return a friendly size error.
+        max_length=DISCORD_MODAL_LATEX_INPUT_CHARS,
     )
 
     def __init__(

--- a/src/latex_module.py
+++ b/src/latex_module.py
@@ -20,6 +20,10 @@ _PREAMBLE_LINE_RE = re.compile(
 _RAW_TIKZ_BODY_CMD_RE = re.compile(
     r"\\(?:draw|node|path|coordinate|filldraw|shade|fill|clip|scope|foreach)\b"
 )
+_TRUNCATED_COMPLEX_DOC_ERROR_RE = re.compile(
+    r"file ended while scanning use of\s+\\end\b",
+    re.IGNORECASE,
+)
 
 _DVIPNG_FAST_PATH_BLOCKLIST = (
     r"\\documentclass\b",
@@ -91,6 +95,24 @@ def text_to_latex(expr: str, output_file: str, dpi=300) -> bool | str:
         )
     except Exception as exc:
         normalized_error = _normalize_error_log(exc)
+        truncated_input_error = _detect_truncated_complex_input_error(
+            expr,
+            normalized_error,
+        )
+        if truncated_input_error:
+            _logger.warning(
+                "Latex2PNG rejected truncated structured input output_file=%s dpi=%s expr_len=%s",
+                output_file,
+                dpi,
+                len(expr),
+            )
+            _logger.debug(
+                "Latex2PNG raw compiler output output_file=%s\n%s",
+                output_file,
+                normalized_error,
+            )
+            return truncated_input_error
+
         user_error = find_latex_error(normalized_error)
 
         if user_error:
@@ -198,6 +220,26 @@ def _is_dvipng_fast_path_eligible(expr: str) -> bool:
         return False
 
     return _matched_dvipng_block_pattern(stripped) is None
+
+
+def _structured_document_kind(expr: str) -> str:
+    stripped = _strip_legacy_latex_prefix(expr).strip()
+    return "TikZ document" if _content_suggests_tikz(stripped) else "LaTeX document"
+
+
+def _detect_truncated_complex_input_error(expr: str, log_text: str) -> str:
+    stripped = _strip_legacy_latex_prefix(expr).strip()
+    if len(stripped) != MAX_LATEX_INPUT_CHARS:
+        return ""
+    if not (_is_full_document(stripped) or _needs_standalone_document_shell(stripped)):
+        return ""
+    if not _TRUNCATED_COMPLEX_DOC_ERROR_RE.search(log_text):
+        return ""
+
+    return (
+        f"Input too long: {_structured_document_kind(stripped)} exceeded the "
+        f"{MAX_LATEX_INPUT_CHARS} character limit and was truncated."
+    )
 
 
 def _render_png_request(

--- a/tests/test_bot_modal_flow.py
+++ b/tests/test_bot_modal_flow.py
@@ -264,7 +264,10 @@ class BotModalFlowTestCase(unittest.TestCase):
         self.assertEqual(modal.dpi, self.bot.DEFAULT_DPI)
         self.assertEqual(modal.title, "Enter LaTeX Code")
         self.assertEqual(modal.latex_input.default, "")
-        self.assertEqual(modal.latex_input.kwargs["max_length"], 3000)
+        self.assertEqual(
+            modal.latex_input.kwargs["max_length"],
+            self.bot.DISCORD_MODAL_LATEX_INPUT_CHARS,
+        )
 
     def test_format_compile_error_description_returns_plain_text_for_friendly_errors(self):
         message = "Input too long: Max is 3000 characters."

--- a/tests/test_latex_module.py
+++ b/tests/test_latex_module.py
@@ -116,6 +116,24 @@ class LatexModuleTestCase(unittest.TestCase):
             "Input too long: 3001 characters. Max is 3000 characters.",
         )
 
+    def test_text_to_latex_surfaces_truncated_tikz_documents_as_length_errors(self):
+        prefix = r"\begin{tikzpicture}\draw (0,0) -- (1,1);"
+        expr = prefix + ("x" * (latex_module.MAX_LATEX_INPUT_CHARS - len(prefix)))
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_base = str(Path(temp_dir) / "truncated_tikz")
+            with patch.object(
+                latex_module,
+                "_render_png_request",
+                side_effect=Exception("! File ended while scanning use of \\end ."),
+            ):
+                result = latex_module.text_to_latex(expr, output_base)
+
+        self.assertEqual(
+            result,
+            "Input too long: TikZ document exceeded the 3000 character limit and was truncated.",
+        )
+
     def test_remove_superfluous_wraps_plain_input_in_display_math(self):
         result = latex_module.remove_superfluous(r"\frac{1}{2}")
 


### PR DESCRIPTION
Fix issue where error returns truncated instead of character limit error 

**User input and error handling improvements:**

* Increased the Discord modal input limit to 4000 characters (`DISCORD_MODAL_LATEX_INPUT_CHARS`), while keeping the renderer's strict limit at 3000 characters to allow for better error feedback. [[1]](diffhunk://#diff-a434d5552ac81a9332e57276722b8816c17a266953b85643f1ee56556fc96c06R313) [[2]](diffhunk://#diff-a434d5552ac81a9332e57276722b8816c17a266953b85643f1ee56556fc96c06L321-R324)
* Added logic to detect when a structured LaTeX document (like TikZ) is truncated due to input length, and return a specific, user-friendly error message indicating the document type and character limit. [[1]](diffhunk://#diff-05def0bf321fa3760fa0be177a3cb8b7696565c6fdaddf6e08bebab40814a0b1R23-R26) [[2]](diffhunk://#diff-05def0bf321fa3760fa0be177a3cb8b7696565c6fdaddf6e08bebab40814a0b1R98-R115) [[3]](diffhunk://#diff-05def0bf321fa3760fa0be177a3cb8b7696565c6fdaddf6e08bebab40814a0b1R225-R244)

**Testing updates:**

* Updated modal flow tests to check for the new modal input character limit.
* Added a new test to ensure that truncated TikZ documents surface the improved error message.