### PR TITLE
Fix/remove legacy commands and privileged intents

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ I wanted a tool that could render LateX in DMs and on Servers. Addtionally I wan
 - Uses timeout guards during rendering and AI responses
 - Local monitoring dashboard with selectable windows (`24h`, `7d`, `30d`, `90d`) and trend charts
 - Optional `/talk-to-me` command powered by Google's Gemini ecosystem
-- Legacy `latex {LaTeX Code}` message command support in servers
 - Button to Edit Code Instead of retyping on Error
 <img width="650" height="175" alt="image" src="https://github.com/user-attachments/assets/75f48881-2fa7-4188-ba98-ac04fbadacff" />
 
@@ -54,7 +53,6 @@ I wanted a tool that could render LateX in DMs and on Servers. Addtionally I wan
 | `/ping` | Health check command. |
 | `/talk-to-me <message>` | Optional conversational command (requires Gemini token). |
 | `/clear-history` | Clear chat history used by `/talk-to-me`. |
-| `latex <latex_code>` | Legacy message-based render command (server messages). |
 
 ## Invite Links
 
@@ -66,7 +64,6 @@ I wanted a tool that could render LateX in DMs and on Servers. Addtionally I wan
 ### TikZ Example (full document)
 
 ```tex
-latex
 \documentclass[border=1mm]{standalone}
 \usepackage{tikz}
 \usepackage{amsmath}

--- a/src/bot.py
+++ b/src/bot.py
@@ -209,7 +209,9 @@ def _create_intents() -> discord.Intents:
 
 
 intents = _create_intents()
-intents.message_content = True
+# Application commands receive their inputs through interactions, so privileged
+# message content access must remain disabled for this slash-command-only bot.
+intents.message_content = False
 intents.guilds = True
 activity = discord.Activity(
     type=discord.ActivityType.playing, name="/help for help"
@@ -341,11 +343,7 @@ class LatexCodeModal(discord.ui.Modal):
         title: str = "Enter LaTeX Code",
     ):
         super().__init__(title=title)
-        # If code prefix from on_message is included, strip it for editor
-        if original_code.startswith("latex "):
-            self.latex_input.default = original_code[6:]
-        else:
-            self.latex_input.default = original_code
+        self.latex_input.default = original_code
         self.dpi = dpi
 
     async def on_submit(self, interaction: discord.Interaction):
@@ -529,8 +527,7 @@ async def help(interaction: discord.Interaction):
     embed = discord.Embed(
         title="Help! - Commands and Features",
         description="Hello!, I'm LaTeX Bot. I can compile your LaTeX code in discord. \n"
-        "Use '/latex' to open a modal editor for your code "
-        "or type latex followed by latex code (server only)",
+        "Use '/latex' to open a modal editor for your code.",
         color=Color.orange(),
     )
     embed.set_author(name=name)
@@ -543,7 +540,6 @@ async def help(interaction: discord.Interaction):
         "/latex-inline                 Single-line slash command input\n\n"
         "/talk-to-me                   Talk to me\n\n"
         "/ping                         See if I'm awake!\n\n"
-        "latex {$$ latex code $$}      Without Slash Commands!\n\n"
         "```",
         inline=False,
     )
@@ -647,126 +643,6 @@ async def clear_history(interaction: discord.Interaction):
         command="clear-history",
         source="slash",
     )
-
-
-# ===== EVENTS =====
-@bot.event
-async def on_message(message):
-    if message.author == bot.user:
-        return
-    if message.content.startswith("latex"):
-        latex_code = message.content
-        channel = message.channel
-        message_id = str(message.id)
-        unique_id = message_id[7:14]
-
-        loop = asyncio.get_running_loop()
-
-        async def notify_legacy(embed, ephemeral=False):
-            return await channel.send(embed=embed, silent=True)
-
-        # Set a timeout of 15 seconds
-        try:
-            output, duration_ms = await compile_queue.execute(
-                loop, text_to_latex, latex_code, unique_id, 275,
-                notify_coro=notify_legacy, timeout=15.0, user_id=message.author.id, source="legacy", dpi=275
-            )
-            if output == "REJECTED":
-                return
-        except asyncio.TimeoutError:
-            logger.warning(
-                "Legacy latex timeout author_id=%s request_id=%s",
-                message.author.id,
-                unique_id,
-            )
-            _safe_record_latex_event(
-                source="legacy",
-                status="timeout",
-                dpi=275,
-                user_id=message.author.id,
-                error_message="LaTeX compilation timed out",
-            )
-            # Handle the timeout case
-            embed = discord.Embed(
-                title="Timeout Error",
-                description="LaTeX compilation took too long. Please try again later or simplify your LaTeX code.",
-                color=Color.red(),
-            )
-            view = FixCodeView(latex_code, 275)
-            await channel.send(embed=embed, view=view, silent=True)
-            return
-        except Exception as exc:
-            logger.exception(
-                "Legacy latex internal error author_id=%s request_id=%s",
-                message.author.id,
-                unique_id,
-            )
-            _safe_record_latex_event(
-                source="legacy",
-                status="internal_error",
-                dpi=275,
-                user_id=message.author.id,
-                error_message=str(exc),
-            )
-            embed = discord.Embed(
-                title="Internal Error",
-                description="Unexpected compile error. Please try again in a moment.",
-                color=Color.red(),
-            )
-            view = FixCodeView(latex_code, 275)
-            await channel.send(embed=embed, view=view, silent=True)
-            return
-
-        if output is True:
-            logger.debug(
-                "Legacy latex compile success author_id=%s request_id=%s",
-                message.author.id,
-                unique_id,
-            )
-            _safe_record_latex_event(
-                source="legacy",
-                status="success",
-                dpi=275,
-                user_id=message.author.id,
-                duration_ms=duration_ms,
-            )
-            file = discord.File(f"{unique_id}.png", filename=f"{unique_id}.png")
-            embed = discord.Embed(color=Color.blue())
-            embed.set_image(url=f"attachment://{unique_id}.png")
-            await channel.send(embed=embed, file=file)
-            _log_command_success(
-                user_id=message.author.id,
-                command="latex",
-                source="legacy",
-                detail=f"request_id={unique_id}",
-            )
-            # remove extra files after
-            os.remove(f"{unique_id}.png")
-        else:
-            logger.warning(
-                "Legacy latex compile failed author_id=%s request_id=%s reason=%s",
-                message.author.id,
-                unique_id,
-                str(output),
-            )
-            _safe_record_latex_event(
-                source="legacy",
-                status="compile_error",
-                dpi=275,
-                user_id=message.author.id,
-                error_message=str(output),
-                duration_ms=duration_ms,
-            )
-            embed = discord.Embed(
-                title="Compilation Error",
-                description=_format_compile_error_description(str(output)),
-                color=Color.red(),
-            )
-            view = FixCodeView(latex_code, 275)
-            await channel.send(embed=embed, view=view, silent=True)
-            return
-    # must be used to process commands else they are overwritten by on_message
-    await bot.process_commands(message)
 
 if __name__ == "__main__":
     token = os.getenv("DISCORD_TOKEN")

--- a/src/bot.py
+++ b/src/bot.py
@@ -191,33 +191,11 @@ except Exception:
 # Default to three local render workers when the bot owns the machine.
 executor = ThreadPoolExecutor(max_workers=LATEX_COMPILE_CONCURRENCY)
 
-
-def _create_intents() -> discord.Intents:
-    default_factory = getattr(discord.Intents, "default", None)
-    if callable(default_factory):
-        intents = default_factory()
-        if isinstance(intents, discord.Intents):
-            return intents
-
-    all_factory = getattr(discord.Intents, "all", None)
-    if callable(all_factory):
-        intents = all_factory()
-        if isinstance(intents, discord.Intents):
-            return intents
-
-    return discord.Intents()
-
-
-intents = _create_intents()
-# Application commands receive their inputs through interactions, so privileged
-# message content access must remain disabled for this slash-command-only bot.
-intents.message_content = False
-intents.guilds = True
+# Defaults include guild lifecycle events but exclude privileged message content.
+intents = discord.Intents.default()
 activity = discord.Activity(
     type=discord.ActivityType.playing, name="/help for help"
 )
-
-# Intents are required for the bot to function properly
 
 bot = commands.Bot(
     command_prefix="/",

--- a/src/latex_module.py
+++ b/src/latex_module.py
@@ -133,7 +133,7 @@ _DVIPNG_FAST_PATH_BLOCKLIST = (
 
 
 def _matched_dvipng_block_pattern(expr: str) -> str | None:
-    stripped = _strip_legacy_latex_prefix(expr).strip()
+    stripped = expr.strip()
     for pattern in _DVIPNG_FAST_PATH_BLOCKLIST:
         if re.search(pattern, stripped):
             return pattern
@@ -475,8 +475,8 @@ def text_to_latex(expr: str, output_file: str, dpi=300) -> bool | str:
      dpi=(1000 , optional) int | sets resolution
     """
 
-    expr = _strip_legacy_latex_prefix(expr)
-
+    # Interaction input is LaTeX source, not a message command. Keep it intact
+    # so command-like text is validated and rendered consistently.
     if len(expr) > MAX_LATEX_INPUT_CHARS:
         return (
             f"Input too long: {len(expr)} characters. "
@@ -598,7 +598,7 @@ def _needs_standalone_document_shell(expr: str) -> bool:
     True when input is not already a full document but needs a standalone file shell
     (TikZ / pgfplots fragments, raw TikZ commands, or leading preamble-only imports).
     """
-    stripped = _strip_legacy_latex_prefix(expr).strip()
+    stripped = expr.strip()
     if not stripped:
         return False
     if _is_full_document(stripped):
@@ -613,7 +613,7 @@ def _needs_standalone_document_shell(expr: str) -> bool:
 
 
 def _is_dvipng_fast_path_eligible(expr: str) -> bool:
-    stripped = _strip_legacy_latex_prefix(expr).strip()
+    stripped = expr.strip()
     if not stripped or _is_full_document(stripped):
         return False
 
@@ -621,12 +621,12 @@ def _is_dvipng_fast_path_eligible(expr: str) -> bool:
 
 
 def _structured_document_kind(expr: str) -> str:
-    stripped = _strip_legacy_latex_prefix(expr).strip()
+    stripped = expr.strip()
     return "TikZ document" if _content_suggests_tikz(stripped) else "LaTeX document"
 
 
 def _detect_truncated_complex_input_error(expr: str, log_text: str) -> str:
-    stripped = _strip_legacy_latex_prefix(expr).strip()
+    stripped = expr.strip()
     if len(stripped) != MAX_LATEX_INPUT_CHARS:
         return ""
     if not (_is_full_document(stripped) or _needs_standalone_document_shell(stripped)):
@@ -676,7 +676,7 @@ def _render_png_request(
 
 
 def _prepare_render_request(expr: str, dpi: int) -> RenderRequest:
-    stripped = _strip_legacy_latex_prefix(expr).strip()
+    stripped = expr.strip()
     preflight_issue = _run_preflight_checks(stripped)
     if (
         preflight_issue
@@ -751,7 +751,7 @@ def _maybe_wrap_raw_tikz_body_with_line_map(
 
 
 def _normalize_full_document_with_line_map(expr: str) -> tuple[str, dict[int, int]]:
-    latex_code = _strip_legacy_latex_prefix(expr).strip()
+    latex_code = expr.strip()
 
     if r"\documentclass" in latex_code:
         return _normalize_first_documentclass_if_needed(latex_code), _identity_line_map(latex_code)
@@ -1073,10 +1073,9 @@ def remove_superfluous(expr: str) -> str:
     """
 
     # Remove any comments
-    # Remove any latex str
     # Replace  \fill[blue] with \draw[fill=blue]
 
-    expr = _strip_legacy_latex_prefix(expr).strip()
+    expr = expr.strip()
 
     if r'\maketitle' in expr or r'\author' in expr or r'\title' in expr:
         expr = expr.replace(r'\maketitle', "")
@@ -1159,13 +1158,6 @@ def _wrap_display_math_batch(blocks: list[str]) -> str:
 
 def _wrap_display_math_content(content: str) -> str:
     return "$\\displaystyle " + content.strip() + "$"
-
-
-def _strip_legacy_latex_prefix(expr: str) -> str:
-    stripped = expr.lstrip()
-    if not re.match(r"latex(?:\s+|$)", stripped):
-        return expr
-    return re.sub(r"^latex(?:\s+|$)", "", stripped, count=1).lstrip()
 
 
 def _has_explicit_math_delimiters(expr: str) -> bool:

--- a/tests/test_bot_modal_flow.py
+++ b/tests/test_bot_modal_flow.py
@@ -88,9 +88,10 @@ def _install_bot_import_stubs() -> None:
     class DummyIntents:
         def __init__(self):
             self.message_content = False
+            self.guilds = True
 
         @staticmethod
-        def all():
+        def default():
             return DummyIntents()
 
     class DummyEmbed:
@@ -266,7 +267,8 @@ class BotModalFlowTestCase(unittest.TestCase):
             self.bot.DISCORD_MODAL_LATEX_INPUT_CHARS,
         )
 
-    def test_bot_does_not_request_message_content_intent(self):
+    def test_bot_uses_default_non_privileged_intents(self):
+        self.assertTrue(self.bot.intents.guilds)
         self.assertFalse(self.bot.intents.message_content)
 
     def test_format_compile_error_description_returns_plain_text_for_friendly_errors(self):

--- a/tests/test_bot_modal_flow.py
+++ b/tests/test_bot_modal_flow.py
@@ -170,9 +170,6 @@ def _install_bot_import_stubs() -> None:
         async def change_presence(self, *args, **kwargs):
             return None
 
-        async def process_commands(self, *args, **kwargs):
-            return None
-
         async def wait_until_ready(self):
             return None
 
@@ -269,6 +266,9 @@ class BotModalFlowTestCase(unittest.TestCase):
             self.bot.DISCORD_MODAL_LATEX_INPUT_CHARS,
         )
 
+    def test_bot_does_not_request_message_content_intent(self):
+        self.assertFalse(self.bot.intents.message_content)
+
     def test_format_compile_error_description_returns_plain_text_for_friendly_errors(self):
         message = "Input too long: Max is 3000 characters."
 
@@ -327,7 +327,7 @@ class BotModalFlowTestCase(unittest.TestCase):
         self.assertIsInstance(modal, self.bot.LatexCodeModal)
         self.assertEqual(modal.title, "Fix LaTeX Code")
         self.assertEqual(modal.dpi, 350)
-        self.assertEqual(modal.latex_input.default, r"\alpha + \beta")
+        self.assertEqual(modal.latex_input.default, r"latex \alpha + \beta")
 
     def test_help_command_describes_modal_first_latex_flow(self):
         interaction = SimpleNamespace(
@@ -348,6 +348,8 @@ class BotModalFlowTestCase(unittest.TestCase):
             "/latex-inline                 Single-line slash command input",
             embed.fields[0]["value"],
         )
+        self.assertNotIn("Without Slash Commands", embed.fields[0]["value"])
+        self.assertNotIn("or type latex", embed.kwargs["description"])
 
     def test_collect_user_stats_includes_manual_users_value(self):
         self.bot.bot.guilds = [

--- a/tests/test_latex_module.py
+++ b/tests/test_latex_module.py
@@ -357,30 +357,15 @@ class LatexModuleTestCase(unittest.TestCase):
             "Input too long: 3001 characters. Max is 3000 characters.",
         )
 
-    def test_text_to_latex_ignores_legacy_prefix_when_counting_input_chars(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            output_base = str(Path(temp_dir) / "legacy_limit")
-            with patch.object(
-                latex_module,
-                "_render_png_request",
-                return_value=PNG_SIGNATURE,
-            ):
-                result = latex_module.text_to_latex(
-                    "latex " + ("x" * latex_module.MAX_LATEX_INPUT_CHARS),
-                    output_base,
-                )
-
-        self.assertTrue(result)
-
-    def test_text_to_latex_rejects_legacy_prefix_input_over_3000_chars(self):
+    def test_text_to_latex_counts_literal_latex_prefix_toward_input_limit(self):
         result = latex_module.text_to_latex(
-            "latex " + ("x" * (latex_module.MAX_LATEX_INPUT_CHARS + 1)),
+            "latex " + ("x" * latex_module.MAX_LATEX_INPUT_CHARS),
             "unused_output",
         )
 
         self.assertEqual(
             result,
-            "Input too long: 3001 characters. Max is 3000 characters.",
+            "Input too long: 3006 characters. Max is 3000 characters.",
         )
 
     def test_text_to_latex_surfaces_truncated_tikz_documents_as_length_errors(self):
@@ -465,10 +450,10 @@ class LatexModuleTestCase(unittest.TestCase):
             "\\end{gathered}$",
         )
 
-    def test_remove_superfluous_strips_legacy_prefix_before_wrapping(self):
+    def test_remove_superfluous_treats_latex_prefix_as_literal_input(self):
         result = latex_module.remove_superfluous(r"latex \alpha + \beta")
 
-        self.assertEqual(result, r"$\displaystyle \alpha + \beta$")
+        self.assertEqual(result, r"$\displaystyle latex \alpha + \beta$")
 
     def test_normalize_full_document_adds_standalone_class_when_missing(self):
         result = latex_module._normalize_full_document(r"\begin{document}x\end{document}")


### PR DESCRIPTION
Remove support for the legacy `latex {LaTeX Code}` server "command", fully migrating the bot to use slash commands and modal inputs for LaTeX rendering. The codebase is simplified by eliminating all logic related to the legacy message command, and tests and documentation are updated to reflect this change. Additionally, the handling of Discord intents is streamlined, and input processing is made more consistent by treating all inputs as literal LaTeX code without stripping any prefixes.

**Removal of legacy message-based command:**

* All code handling the legacy `latex {LaTeX Code}` message command is removed from `src/bot.py`, including the `on_message` event and the `_strip_legacy_latex_prefix` function. [[1]](diffhunk://#diff-a434d5552ac81a9332e57276722b8816c17a266953b85643f1ee56556fc96c06L651-L770) [[2]](diffhunk://#diff-05def0bf321fa3760fa0be177a3cb8b7696565c6fdaddf6e08bebab40814a0b1L1164-L1170)
* Documentation in `README.md` is updated to remove references to the legacy command, focusing on slash commands and modal flows. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57) [[3]](diffhunk://#diff-a434d5552ac81a9332e57276722b8816c17a266953b85643f1ee56556fc96c06L532-R508) [[4]](diffhunk://#diff-a434d5552ac81a9332e57276722b8816c17a266953b85643f1ee56556fc96c06L546) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69)

**Consistent input processing:**

* All LaTeX input is now treated as literal code; no prefixes are stripped. All functions in `src/latex_module.py` that previously called `_strip_legacy_latex_prefix` are updated to process input directly. [[1]](diffhunk://#diff-05def0bf321fa3760fa0be177a3cb8b7696565c6fdaddf6e08bebab40814a0b1L136-R136) [[2]](diffhunk://#diff-05def0bf321fa3760fa0be177a3cb8b7696565c6fdaddf6e08bebab40814a0b1L478-R479) [[3]](diffhunk://#diff-05def0bf321fa3760fa0be177a3cb8b7696565c6fdaddf6e08bebab40814a0b1L601-R601) [[4]](diffhunk://#diff-05def0bf321fa3760fa0be177a3cb8b7696565c6fdaddf6e08bebab40814a0b1L616-R629) [[5]](diffhunk://#diff-05def0bf321fa3760fa0be177a3cb8b7696565c6fdaddf6e08bebab40814a0b1L679-R679) [[6]](diffhunk://#diff-05def0bf321fa3760fa0be177a3cb8b7696565c6fdaddf6e08bebab40814a0b1L754-R754) [[7]](diffhunk://#diff-05def0bf321fa3760fa0be177a3cb8b7696565c6fdaddf6e08bebab40814a0b1L1076-R1078)

**Discord intents handling:**

* Discord bot now uses default (non-privileged) intents, with `message_content` disabled by default, simplifying setup and improving privacy. [[1]](diffhunk://#diff-a434d5552ac81a9332e57276722b8816c17a266953b85643f1ee56556fc96c06L194-L219) [[2]](diffhunk://#diff-2e7df3544cec6ba7783bbea0e8dcb4e9c6062a3edafd63ffb23ee3c51741be67R91-R94) [[3]](diffhunk://#diff-2e7df3544cec6ba7783bbea0e8dcb4e9c6062a3edafd63ffb23ee3c51741be67R270-R273)

**Test updates:**

* Tests are updated to reflect the removal of the legacy command, ensuring that all input is treated as literal and that the bot uses non-privileged intents. [[1]](diffhunk://#diff-961a7ad83030b38b1111b71570f54196d65a3a9c2880fe38505e0419c5ab7680L360-R368) [[2]](diffhunk://#diff-961a7ad83030b38b1111b71570f54196d65a3a9c2880fe38505e0419c5ab7680L468-R456) [[3]](diffhunk://#diff-2e7df3544cec6ba7783bbea0e8dcb4e9c6062a3edafd63ffb23ee3c51741be67L330-R332) [[4]](diffhunk://#diff-2e7df3544cec6ba7783bbea0e8dcb4e9c6062a3edafd63ffb23ee3c51741be67R353-R354) [[5]](diffhunk://#diff-2e7df3544cec6ba7783bbea0e8dcb4e9c6062a3edafd63ffb23ee3c51741be67L173-L175)

**Modal and UI flow simplification:**

* The modal for LaTeX code entry no longer strips any prefix from the input, and the "Fix Code" button preserves the full input as entered. [[1]](diffhunk://#diff-a434d5552ac81a9332e57276722b8816c17a266953b85643f1ee56556fc96c06L344-L347) [[2]](diffhunk://#diff-2e7df3544cec6ba7783bbea0e8dcb4e9c6062a3edafd63ffb23ee3c51741be67L330-R332)