### PR TITLE
Fix/ heartbeat ssl connect error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,4 @@ monitoring/data/*.db-wal
 monitoring/data/*.db-shm
 Thoughts.md
 test_out.txt
+.cursor

--- a/src/bot.py
+++ b/src/bot.py
@@ -319,7 +319,7 @@ async def send_betterstack_heartbeat() -> bool:
     return True
 
 
-@tasks.loop(minutes=5)
+@tasks.loop(minutes=2)
 async def betterstack_heartbeat_task():
     await send_betterstack_heartbeat()
 


### PR DESCRIPTION
This pull request makes a small change to the `betterstack_heartbeat_task` scheduling interval, reducing the time between task executions from 5 minutes to 2 minutes. This will result in more frequent heartbeats being sent.

- Changed the `@tasks.loop` decorator in `src/bot.py` to run every 2 minutes instead of every 5 minutes, increasing the frequency of the `betterstack_heartbeat_task`. 

- Reason? Prevents a slight delay i.e 5 min 2 second delay from causing an incident on betterstack